### PR TITLE
reTurn: fix the async client to choose the DNS result corresponding to local endpoint protocol type

### DIFF
--- a/reTurn/AsyncSocketBase.hxx
+++ b/reTurn/AsyncSocketBase.hxx
@@ -77,7 +77,7 @@ public:
    virtual void handleReadHeader(const asio::error_code& e) { resip_assert(false); }
    virtual void handleServerHandshake(const asio::error_code& e) { resip_assert(false); }
    virtual void handleTcpResolve(const asio::error_code& ec, asio::ip::tcp::resolver::iterator endpoint_iterator) { resip_assert(false); }
-   virtual void handleUdpResolve(const asio::error_code& ec, asio::ip::udp::resolver::iterator endpoint_iterator) { resip_assert(false); }
+   virtual void handleUdpResolve(const asio::error_code& ec, asio::ip::udp::resolver::results_type results) { resip_assert(false); }
    virtual void handleConnect(const asio::error_code& ec, asio::ip::tcp::resolver::iterator endpoint_iterator) { resip_assert(false); }
    virtual void handleClientHandshake(const asio::error_code& ec, asio::ip::tcp::resolver::iterator endpoint_iterator) { resip_assert(false); }
 

--- a/reTurn/AsyncUdpSocketBase.hxx
+++ b/reTurn/AsyncUdpSocketBase.hxx
@@ -36,7 +36,7 @@ protected:
    asio::ip::udp::endpoint mSenderEndpoint;
 
    void handleUdpResolve(const asio::error_code& ec,
-                         asio::ip::udp::resolver::iterator endpoint_iterator) override;
+                         asio::ip::udp::resolver::results_type results) override;
 
 private:
 


### PR DESCRIPTION
Currently, the fist result of the DNS query is used. I faced a situation where the DNS query reported an IPv6 address first while my local endpoint (binded address) is IPv4 so that could not work.

This proposal select the first result where the protocol match the one of the local endpoint.